### PR TITLE
Fixes stable version for 2.0.27

### DIFF
--- a/pdfbox/__init__.py
+++ b/pdfbox/__init__.py
@@ -17,7 +17,7 @@ import jpype
 import jpype.imports
 import pkg_resources
 
-pdfbox_2_0_27_url = r'https://dlcdn.apache.org/pdfbox/2.0.27/pdfbox-2.0.27.jar'
+pdfbox_2_0_27_url = r'https://dlcdn.apache.org/pdfbox/2.0.27/pdfbox-app-2.0.27.jar'
 
 class _PDFBoxVersionsParser(html.parser.HTMLParser):
     """

--- a/pdfbox/__init__.py
+++ b/pdfbox/__init__.py
@@ -17,7 +17,7 @@ import jpype
 import jpype.imports
 import pkg_resources
 
-pdfbox_archive_url = 'https://archive.apache.org/dist/pdfbox/'
+pdfbox_2_0_27_url = r'https://dlcdn.apache.org/pdfbox/2.0.27/pdfbox-2.0.27.jar'
 
 class _PDFBoxVersionsParser(html.parser.HTMLParser):
     """
@@ -63,25 +63,8 @@ class PDFBox(object):
 
         return hashlib.sha512(data).hexdigest() == digest
 
-    def _get_latest_pdfbox_url(self):
-        r = urllib.request.urlopen(pdfbox_archive_url)
-        try:
-            data = r.read()
-        except:
-            raise RuntimeError('error retrieving %s' % pdfbox_archive_url)
-        else:
-            data = data.decode('utf-8')
-        p = _PDFBoxVersionsParser()
-        p.feed(data)
-
-        # Temporarily disallow PDFBox 3 because of change in command line
-        # interface; get major version by splitting base_version because the major attrib is
-        # not defined for some Python installations:
-        versions = list(filter(lambda v: int(pkg_resources.parse_version(v).base_version.split('.')[0])<3,
-                               p.result))
-        latest_version = sorted(versions, key=pkg_resources.parse_version)[-1]
-        return pdfbox_archive_url + latest_version + '/pdfbox-app-' + \
-            latest_version + '.jar'
+    def _get_compatible_pdfbox_url(self):
+        return pdfbox_2_0_27_url
 
     def _get_pdfbox_path(self):
         """
@@ -109,7 +92,7 @@ class PDFBox(object):
         else:
             # If no jar files are cached, find the latest version jar, retrieve it,
             # cache it, and verify its checksum:
-            pdfbox_url = self._get_latest_pdfbox_url()
+            pdfbox_url = self._get_compatible_pdfbox_url()
             sha512_url = pdfbox_url + '.sha512'
             r = urllib.request.urlopen(pdfbox_url)
             try:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME =               'python-pdfbox-v2'
-VERSION =            '0.1.8.2'
+VERSION =            '2.0.27'
 AUTHOR =             'Lev E. Givon'
 AUTHOR_EMAIL =       'lev@columbia.edu'
 URL =                'https://github.com/lebedov/python-pdfbox/'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import re
 from setuptools import find_packages
 from setuptools import setup
 
-NAME =               'python-pdfbox'
+NAME =               'python-pdfbox-v2'
 VERSION =            '0.1.8.2'
 AUTHOR =             'Lev E. Givon'
 AUTHOR_EMAIL =       'lev@columbia.edu'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME =               'python-pdfbox'
-VERSION =            '0.1.8.1'
+VERSION =            '0.1.8.2'
 AUTHOR =             'Lev E. Givon'
 AUTHOR_EMAIL =       'lev@columbia.edu'
 URL =                'https://github.com/lebedov/python-pdfbox/'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME =               'python-pdfbox-v2'
-VERSION =            '2.0.27'
+VERSION =            '2.0.27.4'
 AUTHOR =             'Lev E. Givon'
 AUTHOR_EMAIL =       'lev@columbia.edu'
 URL =                'https://github.com/lebedov/python-pdfbox/'


### PR DESCRIPTION
Apache pdfbox has released version 3.0.* which has a different command which is not compatible with the previous one.
Also the new version is alpha seems not suitable for stable release.

To fix this the version is fixed to final stable version for 2.0.*.